### PR TITLE
Add dual SO101 support

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -77,6 +77,24 @@ while True:
 </hfoption>
 </hfoptions>
 
+### Teleoperate two SO101 arms
+
+To control a dual-arm setup, combine two SO101 robots and leader arms. Example command:
+
+```bash
+python -m lerobot.teleoperate \
+    --robot.type=so101_dual_follower \
+    --robot.left.port=/dev/ttyUSB0 \
+    --robot.left.id=left_arm \
+    --robot.right.port=/dev/ttyUSB1 \
+    --robot.right.id=right_arm \
+    --teleop.type=so101_dual_leader \
+    --teleop.left.port=/dev/ttyUSB2 \
+    --teleop.left.id=left_leader \
+    --teleop.right.port=/dev/ttyUSB3 \
+    --teleop.right.id=right_leader
+```
+
 The teleoperate command will automatically:
 1. Identify any missing calibrations and initiate the calibration procedure.
 2. Connect the robot and teleop device and start teleoperation.

--- a/lerobot/common/robots/so101_dual_follower/__init__.py
+++ b/lerobot/common/robots/so101_dual_follower/__init__.py
@@ -1,0 +1,4 @@
+from .config_so101_dual_follower import SO101DualFollowerConfig
+from .so101_dual_follower import SO101DualFollower
+
+__all__ = ["SO101DualFollowerConfig", "SO101DualFollower"]

--- a/lerobot/common/robots/so101_dual_follower/config_so101_dual_follower.py
+++ b/lerobot/common/robots/so101_dual_follower/config_so101_dual_follower.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from dataclasses import dataclass
+
+from ..config import RobotConfig
+from ..so101_follower.config_so101_follower import SO101FollowerConfig
+
+
+@RobotConfig.register_subclass("so101_dual_follower")
+@dataclass
+class SO101DualFollowerConfig(RobotConfig):
+    """Configuration for a dual SO101 follower robot composed of two single arms."""
+
+    left: SO101FollowerConfig
+    right: SO101FollowerConfig

--- a/lerobot/common/robots/so101_dual_follower/so101_dual_follower.py
+++ b/lerobot/common/robots/so101_dual_follower/so101_dual_follower.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import logging
+from functools import cached_property
+from typing import Any
+
+from ..robot import Robot
+from ..so101_follower import SO101Follower
+from ..utils import ensure_safe_goal_position
+from .config_so101_dual_follower import SO101DualFollowerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SO101DualFollower(Robot):
+    """Dual-arm robot composed of two SO101 follower arms."""
+
+    config_class = SO101DualFollowerConfig
+    name = "so101_dual_follower"
+
+    def __init__(self, config: SO101DualFollowerConfig):
+        super().__init__(config)
+        self.left = SO101Follower(config.left)
+        self.right = SO101Follower(config.right)
+        self.config = config
+
+    def _prefix(self, d: dict[str, Any], prefix: str) -> dict[str, Any]:
+        return {f"{prefix}.{k}": v for k, v in d.items()}
+
+    @cached_property
+    def observation_features(self) -> dict[str, Any]:
+        left = self._prefix(self.left.observation_features, "left")
+        right = self._prefix(self.right.observation_features, "right")
+        return {**left, **right}
+
+    @cached_property
+    def action_features(self) -> dict[str, Any]:
+        left = self._prefix(self.left.action_features, "left")
+        right = self._prefix(self.right.action_features, "right")
+        return {**left, **right}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.left.is_connected and self.right.is_connected
+
+    def connect(self, calibrate: bool = True) -> None:
+        self.left.connect(calibrate)
+        self.right.connect(calibrate)
+        logger.info(f"{self} connected")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.left.is_calibrated and self.right.is_calibrated
+
+    def calibrate(self) -> None:
+        self.left.calibrate()
+        self.right.calibrate()
+
+    def configure(self) -> None:
+        self.left.configure()
+        self.right.configure()
+
+    def _split_action(self, action: dict[str, Any]):
+        left = {k.removeprefix("left."): v for k, v in action.items() if k.startswith("left.")}
+        right = {k.removeprefix("right."): v for k, v in action.items() if k.startswith("right.")}
+        return left, right
+
+    def get_observation(self) -> dict[str, Any]:
+        left_obs = self.left.get_observation()
+        right_obs = self.right.get_observation()
+        return {**self._prefix(left_obs, "left"), **self._prefix(right_obs, "right")}
+
+    def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
+        left_action, right_action = self._split_action(action)
+
+        if self.config.left.max_relative_target is not None:
+            present_pos = self.left.bus.sync_read("Present_Position")
+            left_goal_present = {k: (left_action[k], present_pos[k]) for k in left_action}
+            left_action = ensure_safe_goal_position(left_goal_present, self.config.left.max_relative_target)
+
+        if self.config.right.max_relative_target is not None:
+            present_pos_r = self.right.bus.sync_read("Present_Position")
+            right_goal_present = {k: (right_action[k], present_pos_r[k]) for k in right_action}
+            right_action = ensure_safe_goal_position(
+                right_goal_present, self.config.right.max_relative_target
+            )
+
+        left_sent = self.left.send_action({f"{k}.pos": v for k, v in left_action.items()})
+        right_sent = self.right.send_action({f"{k}.pos": v for k, v in right_action.items()})
+        return {**self._prefix(left_sent, "left"), **self._prefix(right_sent, "right")}
+
+    def disconnect(self) -> None:
+        self.left.disconnect()
+        self.right.disconnect()
+        logger.info(f"{self} disconnected")

--- a/lerobot/common/robots/utils.py
+++ b/lerobot/common/robots/utils.py
@@ -37,6 +37,10 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
         from .so101_follower import SO101Follower
 
         return SO101Follower(config)
+    elif config.type == "so101_dual_follower":
+        from .so101_dual_follower import SO101DualFollower
+
+        return SO101DualFollower(config)
     elif config.type == "lekiwi":
         from .lekiwi import LeKiwi
 

--- a/lerobot/common/teleoperators/so101_dual_leader/__init__.py
+++ b/lerobot/common/teleoperators/so101_dual_leader/__init__.py
@@ -1,0 +1,4 @@
+from .config_so101_dual_leader import SO101DualLeaderConfig
+from .so101_dual_leader import SO101DualLeader
+
+__all__ = ["SO101DualLeaderConfig", "SO101DualLeader"]

--- a/lerobot/common/teleoperators/so101_dual_leader/config_so101_dual_leader.py
+++ b/lerobot/common/teleoperators/so101_dual_leader/config_so101_dual_leader.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from dataclasses import dataclass
+
+from ..config import TeleoperatorConfig
+from ..so101_leader.config_so101_leader import SO101LeaderConfig
+
+
+@TeleoperatorConfig.register_subclass("so101_dual_leader")
+@dataclass
+class SO101DualLeaderConfig(TeleoperatorConfig):
+    """Configuration for a dual SO101 leader teleoperator composed of two single arms."""
+
+    left: SO101LeaderConfig
+    right: SO101LeaderConfig

--- a/lerobot/common/teleoperators/so101_dual_leader/so101_dual_leader.py
+++ b/lerobot/common/teleoperators/so101_dual_leader/so101_dual_leader.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import logging
+from typing import Any
+
+from ..so101_leader import SO101Leader
+from ..teleoperator import Teleoperator
+from .config_so101_dual_leader import SO101DualLeaderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SO101DualLeader(Teleoperator):
+    """Dual teleoperator composed of two SO101 leader arms."""
+
+    config_class = SO101DualLeaderConfig
+    name = "so101_dual_leader"
+
+    def __init__(self, config: SO101DualLeaderConfig):
+        super().__init__(config)
+        self.left = SO101Leader(config.left)
+        self.right = SO101Leader(config.right)
+        self.config = config
+
+    def _prefix(self, d: dict[str, Any], prefix: str) -> dict[str, Any]:
+        return {f"{prefix}.{k}": v for k, v in d.items()}
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        left = self._prefix(self.left.action_features, "left")
+        right = self._prefix(self.right.action_features, "right")
+        return {**left, **right}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.left.is_connected and self.right.is_connected
+
+    def connect(self, calibrate: bool = True) -> None:
+        self.left.connect(calibrate)
+        self.right.connect(calibrate)
+        logger.info(f"{self} connected")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.left.is_calibrated and self.right.is_calibrated
+
+    def calibrate(self) -> None:
+        self.left.calibrate()
+        self.right.calibrate()
+
+    def configure(self) -> None:
+        self.left.configure()
+        self.right.configure()
+
+    def get_action(self) -> dict[str, Any]:
+        left_act = self.left.get_action()
+        right_act = self.right.get_action()
+        return {**self._prefix(left_act, "left"), **self._prefix(right_act, "right")}
+
+    def send_feedback(self, feedback: dict[str, Any]) -> None:
+        # Not implemented
+        pass
+
+    def disconnect(self) -> None:
+        self.left.disconnect()
+        self.right.disconnect()
+        logger.info(f"{self} disconnected")

--- a/lerobot/common/teleoperators/utils.py
+++ b/lerobot/common/teleoperators/utils.py
@@ -33,6 +33,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> Teleoperator:
         from .so101_leader import SO101Leader
 
         return SO101Leader(config)
+    elif config.type == "so101_dual_leader":
+        from .so101_dual_leader import SO101DualLeader
+
+        return SO101DualLeader(config)
     elif config.type == "stretch3":
         from .stretch3_gamepad import Stretch3GamePad
 


### PR DESCRIPTION
## Summary
- add `SO101DualFollower` robot and config
- add `SO101DualLeader` teleoperator and config
- expose dual-arm classes in factories
- document dual-arm teleoperation usage

## Testing
- `ruff format` on new files
- `pytest -k dual -q` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pre-commit` *(fails: couldn't setup python3.10 environment)*

------
https://chatgpt.com/codex/tasks/task_e_6860023672288332a87122022bfbaf87